### PR TITLE
Add Capability to Install Custom AgentLoopManger [May be removed later]

### DIFF
--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -232,6 +232,9 @@ agent:
     # Class name of the custom async server class (e.g. AsyncvLLMServer)
     name: null
 
+# custom agent loop manager
+custom_agent_loop_manager: null
+
 # Specifies the tensor bucket size (in megabytes) for batch weight updates during rollout operations.
 # This parameter controls the maximum payload size for a single weight update request.
 # Reference: https://github.com/volcengine/verl/pull/2418

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -775,7 +775,8 @@ class RayPPOTrainer:
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False
         if self.config.actor_rollout_ref.rollout.mode == "async":
-            from verl.experimental.agent_loop import AgentLoopManager
+            # from verl.experimental.agent_loop import AgentLoopManager
+            from skyrl_expr.verl_async_manager import SkyAgentLoopManager as AgentLoopManager
 
             self.async_rollout_mode = True
             if self.config.reward_model.enable and self.config.reward_model.enable_resource_pool:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -436,7 +436,7 @@ class RayPPOTrainer:
         base_data = {
             "input": inputs,
             "output": outputs,
-            "gts": gts,
+            # "gts": gts, # FIXME
             "score": scores,
             "step": [self.global_steps] * n,
         }

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -775,8 +775,17 @@ class RayPPOTrainer:
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False
         if self.config.actor_rollout_ref.rollout.mode == "async":
-            # from verl.experimental.agent_loop import AgentLoopManager
-            from skyrl_expr.verl_async_manager import SkyAgentLoopManager as AgentLoopManager
+
+            fqdn = self.config.actor_rollout_ref.rollout.custom_agent_loop_manager
+            if not fqdn:
+                from verl.experimental.agent_loop import AgentLoopManager
+            else:
+                import importlib
+                module_name, class_name = fqdn.rsplit(".", 1)
+                rollout_module = importlib.import_module(module_name)
+                AgentLoopManager = getattr(rollout_module, class_name)
+
+                # from skyrl_expr.verl_async_manager import SkyAgentLoopManager as AgentLoopManager
 
             self.async_rollout_mode = True
             if self.config.reward_model.enable and self.config.reward_model.enable_resource_pool:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -436,7 +436,7 @@ class RayPPOTrainer:
         base_data = {
             "input": inputs,
             "output": outputs,
-            # "gts": gts, # FIXME
+            "gts": gts,
             "score": scores,
             "step": [self.global_steps] * n,
         }

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -158,7 +158,6 @@ def load_reward_manager(
             type[AbstractRewardManager],
             load_extern_object(module_path=module_cfg.path, object_name=reward_manager_cls_name),
         )
-        # reward_manager_cls = load_extern_object(module_path=module_cfg.path, object_name=reward_manager_cls_name)
 
     if compute_score is None:
         sandbox_config = config.reward_model.get("sandbox_fusion")

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
     from verl.trainer.config.config import ModuleConfig, RewardManagerConfig
     from verl.workers.reward_manager.abstract import AbstractRewardManager, RawRewardFn
 else:
+    # this is needed for the importlib path
+    from verl.workers.reward_manager.abstract import AbstractRewardManager
     try:
         from verl.experimental.reward.reward_loop.base import RewardLoopManagerBase
     except ImportError:
@@ -156,6 +158,7 @@ def load_reward_manager(
             type[AbstractRewardManager],
             load_extern_object(module_path=module_cfg.path, object_name=reward_manager_cls_name),
         )
+        # reward_manager_cls = load_extern_object(module_path=module_cfg.path, object_name=reward_manager_cls_name)
 
     if compute_score is None:
         sandbox_config = config.reward_model.get("sandbox_fusion")

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -169,6 +169,8 @@ class RolloutConfig(BaseConfig):
 
     agent: AgentLoopConfig = field(default_factory=AgentLoopConfig)
 
+    custom_agent_loop_manager: Optional[str] = None
+
     trace: TraceConfig = field(default_factory=TraceConfig)
 
     multi_turn: MultiTurnConfig = field(default_factory=MultiTurnConfig)


### PR DESCRIPTION
For skyrl, to use the upstream trainer, we need to install a custom `AgentLoopManager`, which is currently not available in VERL.

The better thing would be to use VERL's API for custom `AgentLoop` impls, like this one for [langgraph](https://github.com/verl-project/verl-recipe/tree/main/langgraph_agent/example). But without further refactoring of skyrl-agent this is currently not possible

- there is only one small bugfix where there is a missing import of the `AbstractRewardManager`, see https://github.com/fabianlim/verl/commit/8924ba208afe897bf57fe75fd1c7530a9f747058. This bug prevents the use of the `importlib` method of installing a custom reward manager